### PR TITLE
Better "Created Date" when importing new notes

### DIFF
--- a/geeknote.py
+++ b/geeknote.py
@@ -185,10 +185,11 @@ class GeekNote(object):
         note.content = self.getNoteStore().getNoteContent(self.authToken, note.guid)
 
     @EdamException
-    def createNote(self, title, content, tags=None, notebook=None):
+    def createNote(self, title, content, tags=None, notebook=None, created=None):
         note = Types.Note()
         note.title = title
         note.content = content
+        note.created = created
 
         if tags:
             note.tagNames = tags

--- a/gnsync.py
+++ b/gnsync.py
@@ -162,7 +162,8 @@ class GNSync:
         result = GeekNote().createNote(
             title=file_note['name'],
             content=content,
-            notebook=self.notebook_guid)
+            notebook=self.notebook_guid,
+            created=file_note['mtime'])
         
         if result:
             logger.info('Note "{0}" was created'.format(file_note['name']))


### PR DESCRIPTION
Use the unix mtime as the created date. It isn't the real created date, but it is closer than the default (current) date and time.

It makes importing existing notes much more useful because the current dates are preserved.
