### PR TITLE
Add .markdown suffix to editor's temporary file

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -58,7 +58,7 @@ def edit(content=None):
     if not isinstance(content, str):
         raise Exception("Note content must be an instanse of string, '%s' given." % type(content))
 
-    (tmpFileHandler, tmpFileName) = tempfile.mkstemp()
+    (tmpFileHandler, tmpFileName) = tempfile.mkstemp(suffix=".markdown")
     
     os.write(tmpFileHandler, ENMLtoText(content))
     os.close(tmpFileHandler)


### PR DESCRIPTION
This way the text editor can detect the file type.

Before: `/tmp/tmpQwSEId`
After: `/tmp/tmpQwSEId.markdown`
