### PR TITLE
Does not allow more than 50 notes to be returned while searching

### DIFF
--- a/geeknote.py
+++ b/geeknote.py
@@ -166,7 +166,7 @@ class GeekNote(object):
     WORK WITH NOTEST
     """
     @EdamException
-    def findNotes(self, keywords, count, createOrder=False):
+    def findNotes(self, keywords, count, createOrder=False, offset=0):
         
         noteFilter = NoteStore.NoteFilter(order=Types.NoteSortOrder.RELEVANCE)
         if createOrder:
@@ -174,7 +174,7 @@ class GeekNote(object):
 
         if keywords:
             noteFilter.words = keywords
-        return self.getNoteStore().findNotes(self.authToken, noteFilter, 0, count)
+        return self.getNoteStore().findNotes(self.authToken, noteFilter, offset, count)
 
     @EdamException
     def loadNoteContent(self, note):
@@ -662,6 +662,19 @@ class Notes(GeekNoteConnector):
 
         createFilter = True if search == "*" else False
         result = self.getEvernote().findNotes(request, count, createFilter)
+        
+        # Reduces the count by the amount of notes already retrieved
+        update_count = lambda c: max(c - len(result.notes), 0)
+        
+        count = update_count(count)
+        
+        # Evernote api will only return so many notes in one go. Checks for more 
+        # notes to come whilst obeying count rules
+        while ((result.totalNotes != len(result.notes)) and count != 0):
+            offset = len(result.notes)
+            result.notes += self.getEvernote().findNotes(request, count,
+                    createFilter, offset).notes
+            count = update_count(count)
 
         if result.totalNotes == 0:
             out.successMessage("Notes have not been found.")


### PR DESCRIPTION
Was trying to retrieve entire notebook which had more than 50 notes in it and I was getting limited by one request to evenote. Turn out evernote will only return so many notes in one request (http://discussion.evernote.com/topic/14303-grab-all-notes-in-a-notebook/#11). 

This will make geeknote make as many requests as it needs to get all the notes whilst still obeying the count limits.
