### PR TITLE
Handle non markdown files properly in gnsync

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -12,7 +12,21 @@ import re
 import config
 from storage import Storage
 from log import logging
+from xml.sax.saxutils import escape, unescape
 
+# escape() and unescape() takes care of &, < and >.
+html_escape_table = {
+    '"': "&quot;",
+    "'": "&apos;",
+    '\n': "<br />",
+}
+html_unescape_table = {v:k for k, v in html_escape_table.items()}
+
+def HTMLEscape(text):
+    return escape(text, html_escape_table)
+
+def HTMLUnescape(text):
+    return unescape(text, html_unescape_table)
 
 def ENMLtoText(contentENML):
     content = html2text.html2text(contentENML.decode('utf-8'))
@@ -25,7 +39,7 @@ def wrapENML(contentHTML):
     body += '<en-note>%s</en-note>' % contentHTML
     return body
 
-def textToENML(content, raise_ex=False):
+def textToENML(content, raise_ex=False, format='markdown'):
     """
     Create an ENML format of note.
     """
@@ -35,9 +49,12 @@ def textToENML(content, raise_ex=False):
         content = unicode(content,"utf-8")
         # add 2 space before new line in paragraph for cteating br tags
         content = re.sub(r'([^\r\n])([\r\n])([^\r\n])', r'\1  \n\3', content)
-        contentHTML = markdown.markdown(content).encode("utf-8")
-        # remove all new-lines characters in html
-        contentHTML = re.sub(r'\n', r'', contentHTML)
+        if format=='markdown':
+          contentHTML = markdown.markdown(content).encode("utf-8")
+          # remove all new-lines characters in html
+          contentHTML = re.sub(r'\n', r'', contentHTML)
+        else:
+          contentHTML = HTMLEscape(content)
         return wrapENML(contentHTML)
     except:
         if raise_ex:

--- a/gnsync.py
+++ b/gnsync.py
@@ -181,7 +181,7 @@ class GNSync:
         content = open(path, "r").read()
         # strip unprintable characters
         content = ''.join(s for s in content if s in string.printable)
-        content = editor.textToENML(content=content, raise_ex=True)
+        content = editor.textToENML(content=content, raise_ex=True, format=self.format)
         
         if content is None:
             logger.warning("File {0}. Content must be an UTF-8 encode.".format(path))


### PR DESCRIPTION
First commit removes unprintable characters from files before gnsync uploads them - before characters like unix control codes (not uncommon in log files) would cause a silent[^1] failure.

Second commit means that if you call gnsync with format = plain, it won't try and parse each note as markdown and simply uses xml.sax to handle html escaping. This _dramatically_ speeds up processing on larger log files (a 256K log file took an unknown[^2] number of minutes before on my server, but now is uploaded in ~10s)

[^1]: Admittedly it does get logged in the logfile, but there is no indication of failure on the cli.
[^2]: I.e. I gave up waiting and killed it.
