### PR TITLE
Add support for accounts using two factor authentication (fixes #118)

### DIFF
--- a/out.py
+++ b/out.py
@@ -101,6 +101,18 @@ def GetUserCredentials():
 
     return (login, password)
 
+@preloaderPause
+def GetUserAuthCode():
+    """Prompts the user for a two factor auth code."""
+    try:
+        code = None
+        if code is None:
+          code = rawInput("Code: ")
+    except (KeyboardInterrupt, SystemExit):
+        tools.exit()
+
+    return code
+
 @preloaderStop
 def SearchResult(listItems, request, **kwargs):
     """Печать результатов поиска"""


### PR DESCRIPTION
Spots when the login action returns a 302 indicating there is the second login step of two factor authentication involved and handles that in the same manner as before.

Third attempt, now from a side branch and the correct one at that.
