### PR TITLE
html2text should not wrap lines! use html2text.BODY_WIDTH = 0

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import tempfile
+from bs4 import BeautifulSoup
 import html2text as html2text
 import markdown2 as markdown
 import tools
@@ -29,7 +30,13 @@ def HTMLUnescape(text):
 
 def ENMLtoText(contentENML):
     html2text.BODY_WIDTH = 0
-    content = html2text.html2text(contentENML.decode('utf-8'))
+    soup = BeautifulSoup(contentENML.decode('utf-8'))
+
+    for section in soup.select('li > p'):
+        section.replace_with( section.contents[0] )
+
+    content = html2text.html2text(soup.prettify())
+
     content = re.sub(r' *\n', os.linesep, content)
     return content.encode('utf-8')
 

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         'html2text',
         'sqlalchemy',
         'markdown2',
+        'beautifulsoup4',
         'thrift'
     ],
 


### PR DESCRIPTION
When using Vim, or Evernote, or any other editor that has line wrapping setup, odds are you're not going to be keeping yourself within 80 characters.

This basically keeps everything consistent. 

One line wonder.
