### PR TITLE
Fix editor.py for windows users

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -75,14 +75,14 @@ class Editor(object):
             content = ""
         try:
             content = unicode(content, "utf-8")
-            # add 2 space before new line in paragraph for cteating br tags
+            # add 2 space before new line in paragraph for creating br tags
             content = re.sub(r'([^\r\n])([\r\n])([^\r\n])', r'\1  \n\3', content)
             if format=='markdown':
               contentHTML = markdown.markdown(content).encode("utf-8")
               # remove all new-lines characters in html
               contentHTML = re.sub(r'\n', r'', contentHTML)
             else:
-              contentHTML = self.HTMLEscape(content)
+              contentHTML = Editor.HTMLEscape(content)
             return Editor.wrapENML(contentHTML)
         except:
             if raise_ex:
@@ -97,7 +97,7 @@ class Editor(object):
 
     def __init__(self, content):
         if not isinstance(content, str):
-            raise Exception("Note content must be an instanse "
+            raise Exception("Note content must be an instance "
                             "of string, '%s' given." % type(content))
             
         (tempfileHandler, tempfileName) = tempfile.mkstemp(suffix=".markdown")


### PR DESCRIPTION
Calling gnsync under windows raises:

> Error while parsing text to
> html.
> Content must be an utf-8 encode.

Global name 'self' is not
defined on line 85 in editor.py
I replaced it with a straight call
to the Editor object.

---

-2 typos :-)
