### PR TITLE
Remove HTML tags added by BeautifulSoup (issue #178)

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -88,7 +88,7 @@ class Editor(object):
             if format=='markdown':
               contentHTML = markdown.markdown(content).encode("utf-8")
               # Non-Pretty HTML output
-              contentHTML = str(BeautifulSoup(contentHTML).body.next)
+              contentHTML = str(BeautifulSoup(contentHTML, 'html.parser'))
             else:
               contentHTML = Editor.HTMLEscape(content)
             return Editor.wrapENML(contentHTML)


### PR DESCRIPTION
BeautifulSoup automatically added full HTML tags to the converted markdown, causing Evernote to refuse to update.
