### PR TITLE
fix gnsync bug for some markdown files

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -56,12 +56,13 @@ class Editor(object):
             section.replace_with( section.contents[0] )
 
         for section in soup.select('li > br'):
-            next_sibling = section.next_sibling.next_sibling
-            if next_sibling:
-                if next_sibling.find('li'):
+            if section.next_sibling:
+                next_sibling = section.next_sibling.next_sibling
+                if next_sibling:
+                    if next_sibling.find('li'):
+                        section.extract()
+                else:
                     section.extract()
-            else:
-                section.extract()
 
         content = html2text.html2text(soup.prettify())
         content = re.sub(r' *\n', os.linesep, content)


### PR DESCRIPTION
Handle case where 'NoneType' object has no attribute 'next_sibling'
