### PR TITLE
Make the prompt for the TFA code more descriptive.

### DIFF
--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -111,7 +111,7 @@ def GetUserAuthCode():
     try:
         code = None
         if code is None:
-          code = rawInput("Code: ")
+          code = rawInput("Two-Factor Authentication Code: ")
     except (KeyboardInterrupt, SystemExit):
         tools.exit()
 


### PR DESCRIPTION
Currently, geeknote displays the following prompt:

```
Code:
```

This is confusing to users. This pull request aims to alleviate that confusion by specifying that the code is for the purpose of [two-factor authentication](http://en.wikipedia.org/wiki/Two-factor_authentication).
