### PR TITLE
Added attributes info to note show (inside META part)

### DIFF
--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -155,6 +155,9 @@ def showNote(note):
               (printDate(note.created).ljust(15, " ")))
     printLine("Updated: %s" %
               (printDate(note.updated).ljust(15, " ")))
+    for key, value in note.attributes.__dict__.items():
+        if value:
+          printLine("%s: %s" % (key, value))
     separator("-", "CONTENT")
     if note.tagNames:
         printLine("Tags: %s" % ', '.join(note.tagNames))


### PR DESCRIPTION
This commit permits to see the **URL** and the **source** of the note (and subjectDate, latitude, longitude, altitude, author, source, sourceURL, sourceApplication, shareDate, reminderOrder, reminderDoneTime, reminderTime, placeName, contentClass, applicationData, lastEditedBy, classifications, creatorId, lastEditorId).

**The values ​​are displayed only if they are not empty.**

_Example :_

```
jer@j:~$ geeknote show 61
################## TITLE ##################
Added attributes info to note show (inside META part) by jersou · Pull Request #199 · VitaliyRodnenko/geeknote
=================== META ==================
Created: 14/06/2014 09:44
Updated: 14/06/2014 09:44
sourceURL: https://github.com/VitaliyRodnenko/geeknote/pull/199
source: Clearly
----------------- CONTENT -----------------
  Added attributes info to note show (inside META part) #199

[ jersou ](https://github.com/jersou) wants to merge 1 commit into
VitaliyRodnenko:master from jersou:master
```
