### PR TITLE
Wrap isatty checks in try/except block.

### DIFF
--- a/geeknote/config.py
+++ b/geeknote/config.py
@@ -19,8 +19,12 @@ CONSUMER_SECRET_SANDBOX = "ed0fcc0c97c032a5"
 
 VERSION = 0.1
 
-IS_IN_TERMINAL = sys.stdin.isatty()
-IS_OUT_TERMINAL = sys.stdout.isatty()
+try:
+    IS_IN_TERMINAL = sys.stdin.isatty()
+    IS_OUT_TERMINAL = sys.stdout.isatty()
+except:
+    IS_IN_TERMINAL = False
+    IS_OUT_TERMINAL = False
 
 # Application path
 APP_DIR = os.path.join(os.getenv("HOME") or os.getenv("USERPROFILE"),  ".geeknote")


### PR DESCRIPTION
The sys.stdin.isatty() and sys.stdout.isatty() functions do not
exist when geeknote is imported into a vim python module
giving rise to various 'AttributeError: isatty' errors. Wrap the
calls in a try/except block and handle the exception by setting
IS_IN_TERMINAL and IS_OUT_TERMINAL to False.
