### PR TITLE
Add support for preformatted notes

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -63,7 +63,7 @@ class Editor(object):
             if len(sections) >= 1:
                 content = ''
                 for c in sections[0].contents:
-                    content += str(c)
+                    content = u''.join((content, c))
                 pass
             else:
                 format = 'default'
@@ -111,7 +111,7 @@ class Editor(object):
             # perform any parsing/mutation.
             #
             elif format=='pre':
-              contentHTML = '<pre>' + content + '</pre>'
+              contentHTML = u''.join(('<pre>', content, '</pre>')).encode("utf-8")
             else:
               contentHTML = Editor.HTMLEscape(content)
             return Editor.wrapENML(contentHTML)


### PR DESCRIPTION
I prefer to create, edit, and view my notes from within my editor. Therefore, I don't want the content of my notes to be changed in anyway. Unfortunately, as a result of various conversions that geeknote performs (markdown->html->enml->html->text) numerous changes are made to the original note content. It is even possible to lose content. This patch introduces the notion of preformatted notes. When asked to save a preformatted note, geeknote will simply wrap the content with a 'pre' block and then wrap the resulting content with the necessary ENML xml header. It will not attempt any markdown to html or text to html conversion. Likewise, when asked to read a preformatted note, geeknote will simply convert the ENML content to HTML and return the content it exacts from the first 'pre' block.
