### PR TITLE
Implement customizing markdown2 extra syntax.

### DIFF
--- a/geeknote/argparser.py
+++ b/geeknote/argparser.py
@@ -31,6 +31,11 @@ COMMANDS_DICT = {
             "--editor": {"help": "Set the editor, which use to "
                                  "edit and create notes.",
                          "emptyValue": '#GET#'},
+            "--extras": {"help": "Set the markdown2 extra syntax, which use "
+                                 "to convert markdown text to HTML.  "
+                                 "Please visit http://tinyurl.com/q459lur "
+                                 "to get detail.",
+                         "emptyValue": '#GET#'},
         }
     },
 

--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -87,7 +87,11 @@ class Editor(object):
             # add 2 space before new line in paragraph for creating br tags
             content = re.sub(r'([^\r\n])([\r\n])([^\r\n])', r'\1  \n\3', content)
             if format=='markdown':
-              contentHTML = markdown.markdown(content).encode("utf-8")
+              storage = Storage()
+              extras = storage.getUserprop('markdown2_extras')
+              #contentHTML = markdown.markdown(content).encode("utf-8")
+              contentHTML = markdown.markdown(
+                      content, extras=extras).encode("utf-8")
               # Non-Pretty HTML output
               contentHTML = str(BeautifulSoup(contentHTML, 'html.parser'))
             else:

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -358,7 +358,7 @@ class User(GeekNoteConnector):
             return tools.exitErr()
 
     @GeekNoneDBConnectOnly
-    def settings(self, editor=None):
+    def settings(self, editor=None, extras=None):
         storage = self.getStorage()
         if editor:
             if editor == '#GET#':
@@ -369,13 +369,24 @@ class User(GeekNoteConnector):
             else:
                 storage.setUserprop('editor', editor)
                 out.successMessage("Changes have been saved.")
+        elif extras:
+            if extras == '#GET#':
+                extras = storage.getUserprop('markdown2_extras')
+                if not extras:
+                    extras = None
+                out.successMessage("Current markdown2 extras is : %s" % extras)
+            else:
+                storage.setUserprop('markdown2_extras', extras.split(','))
+                out.successMessage("Changes have been saved.")
         else:
             settings = ('Geeknote',
                         '*' * 30,
                         'Version: %s' % config.VERSION,
                         'App dir: %s' % config.APP_DIR,
                         'Error log: %s' % config.ERROR_LOG,
-                        'Current editor: %s' % storage.getUserprop('editor'))
+                        'Current editor: %s' % storage.getUserprop('editor'),
+                        'Markdown2 Extras: %s' % ','.join(storage.getUserprop(
+                            'markdown2_extras')))
 
             user_settings = storage.getUserprops()
 


### PR DESCRIPTION
I would like to add the feature to customize markdown and here is my code.

markdown2 don't handle the syntax `code` in default.
markdown2 actually can do this by add 'extras' parameter in creating markdown object.
So I add argument in settings() to make user can choose the extra syntax they want.
