### PR TITLE
Made gnsync work on narrow Python builds

### DIFF
--- a/geeknote/gnsync.py
+++ b/geeknote/gnsync.py
@@ -23,8 +23,15 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 
+# determine if this is a narrow build or wide build (or py3k)
+try:
+    unichr(0x10000)
+    MAX_CHAR = 0x110000
+except ValueError:
+    MAX_CHAR = 0x9999
+
 # http://stackoverflow.com/a/93029
-CONTROL_CHARS = ''.join(c for c in (unichr(i) for i in xrange(0x110000)) \
+CONTROL_CHARS = ''.join(c for c in (unichr(i) for i in xrange(MAX_CHAR)) \
                 if c not in string.printable and unicodedata.category(c) == 'Cc')
 CONTROL_CHARS_RE = re.compile('[%s]' % re.escape(CONTROL_CHARS))
 def remove_control_characters(s):


### PR DESCRIPTION
"Narrow" builds of python only support 3-byte Unicode characters, but
gnsync required four-byte support. This change discovers whether 3- or
4-byte Unicode is supported and does the right thing accordingly.
