### PR TITLE
Fix error in textToENML, BeautifulSoup not parsing strings with non ascii characters

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -87,7 +87,7 @@ class Editor(object):
             # add 2 space before new line in paragraph for creating br tags
             content = re.sub(r'([^\r\n])([\r\n])([^\r\n])', r'\1  \n\3', content)
             if format=='markdown':
-              contentHTML = markdown.markdown(content).encode("utf-8")
+              contentHTML = markdown.markdown(content)
               # Non-Pretty HTML output
               contentHTML = str(BeautifulSoup(contentHTML, 'html.parser'))
             else:


### PR DESCRIPTION
When there are non ascii characters in edit command, it throws:

```
 Error while parsing text to html. Content must be an UTF-8 encode.
```
