### PR TITLE
Add a --raw flag to the show command

### DIFF
--- a/geeknote/argparser.py
+++ b/geeknote/argparser.py
@@ -89,6 +89,12 @@ COMMANDS_DICT = {
             "--note": {"altName": "-n",
                        "help": "The name or ID from the previous "
                                "search of a note to show."},
+        },
+        "flags": {
+            "--raw": {"altName": "-w",
+                       "help": "Show the raw note body",
+                       "value": True,
+                       "default": False},
         }
     },
     "find": {

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -625,7 +625,7 @@ class Notes(GeekNoteConnector):
         else:
             out.failureMessage("Error while deleting the note.")
 
-    def show(self, note):
+    def show(self, note, raw=None):
 
         self.connectToEvertone()
 
@@ -634,7 +634,10 @@ class Notes(GeekNoteConnector):
         out.preloader.setMessage("Loading note...")
         self.getEvernote().loadNoteContent(note)
 
-        out.showNote(note)
+        if raw:
+          out.showNoteRaw(note)
+        else:
+          out.showNote(note)
 
     def _parceInput(self, title=None, content=None, tags=None, notebook=None, note=None):
         result = {

--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -178,6 +178,9 @@ def showNote(note):
 
     printLine(Editor.ENMLtoText(note.content))
 
+@preloaderStop
+def showNoteRaw(note):
+    printLine(Editor.ENMLtoText(note.content, 'pre'))
 
 @preloaderStop
 def showUser(user, fullInfo):


### PR DESCRIPTION
This shows just the body of the note and allows the user to pipe the
output to another tool. Useful in combination with pandoc to create
LaTeX PDF files from notes. Example:

    geeknote show "My note" --raw | pandoc -s - -o my_note.tex
    xelatex my_note.tex