### PR TITLE
Fixed resources is not defined bug in _parseInput

### DIFF
--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -192,11 +192,11 @@ class GeekNote(object):
 
     @EdamException
     def createNote(self, title, content, tags=None, notebook=None, created=None, resources=None):
-        
+
         def make_resource(filename):
             try:
                 mtype = mimetypes.guess_type(filename)[0]
-                    
+
                 if mtype.split('/')[0] == "text":
                     rmode = "r"
                 else:
@@ -210,10 +210,10 @@ class GeekNote(object):
                     data = f.read()
                     md5 = hashlib.md5()
                     md5.update(data)
-                    
-                    resource.data.bodyHash = md5.hexdigest() 
+
+                    resource.data.bodyHash = md5.hexdigest()
                     resource.data.body = data
-                    resource.data.size = len(data) 
+                    resource.data.size = len(data)
                     resource.mime = mtype
                     resource.attributes = Types.ResourceAttributes()
                     resource.attributes.fileName = os.path.basename(filename)
@@ -237,10 +237,10 @@ class GeekNote(object):
         if resources:
             """ make EverNote API resources """
             note.resources = map(make_resource, resources)
-            
+
             """ add to content """
             resource_nodes = ""
-            
+
             for resource in note.resources:
                 resource_nodes += '<en-media type="%s" hash="%s" />' % (resource.mime, resource.data.bodyHash)
 
@@ -702,7 +702,7 @@ class Notes(GeekNoteConnector):
             "content": content,
             "tags": tags,
             "notebook": notebook,
-            "resources": resources if resources else [],
+            "resources": [] if 'resources' not in vars() else resources,
         }
         result = tools.strip(result)
 


### PR DESCRIPTION
Fix for error on in the _parseInput function of geeknote.py

Python was throwing an error due to name resources being evaluated
before it was defined.  Someone more familiar with the code base of
geeknote can likely do a better job and make sure that the resources var
is defined (even if None).  For now I just check (correctly) that
'resources' lives in vars().