### PR TITLE
fix crash when timestamp is 13 digits on python2.7

### DIFF
--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -239,6 +239,10 @@ def rawInput(message, isPass=False):
 
 
 def printDate(timestamp):
+    
+    if len(str(timestamp)) == 13:
+	    timestamp = int(str(timestamp)[0:-3])
+
     return time.strftime("%d.%m.%Y", time.localtime(timestamp / 1000))
 
 


### PR DESCRIPTION
when I tried 

`geeknote show "pattern*"` 

I got an exception for *ValueError: year is out of range*

my python version is 

Python 2.7.8 :: Anaconda 2.1.0 (x86_64)