### PR TITLE
Set html2text.body_width to 0 in correct way.

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -76,7 +76,6 @@ class Editor(object):
 
     @staticmethod
     def ENMLtoText(contentENML):
-        html2text.BODY_WIDTH = 0
         soup = BeautifulSoup(contentENML.decode('utf-8'))
 
         for section in soup.select('li > p'):
@@ -101,6 +100,7 @@ class Editor(object):
 
 #       content = html2text.html2text(soup.prettify())
         content = html2text.html2text(str(soup))
+        content = html2text.html2text(str(soup).decode('utf-8'), '', 0)
 
         content = re.sub(r' *\n', os.linesep, content)
 


### PR DESCRIPTION
This patch set html2text.body_width to 0 in correct manner to disable text wrapping. This patch also includes Unicode text handling fix suggested in #261.