### PR TITLE
When using an editor, if saving fails, keep temp file and warn the user about it. Otherwise, delete it.

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -257,3 +257,6 @@ class Editor(object):
         newContent = open(self.tempfile, 'r').read()
 
         return newContent
+
+    def deleteTempfile(self):
+        os.remove(self.tempfile)

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -625,7 +625,14 @@ class Notes(GeekNoteConnector):
                 # check if thread is alive here before sleep to avoid losing data saved during this 5 secs
                 break
             time.sleep(5)
+        self._finalizeEditor(editor, result)
         return result
+
+    def _finalizeEditor(self, editor, result):
+        if result:
+            editor.deleteTempfile()
+        else:
+            out.failureMessage("As I couldn't save the note, I've left it in %s" % editor.tempfile)
 
     def create(self, title, content=None, tags=None, notebook=None, resource=None):
 


### PR DESCRIPTION
Really simple handling of the issue #234. When an error happens while saving from an editor, at least warn about it and show the path to the temp file. Otherwise, remove the file, as it is not automatically removed.