### PR TITLE
Sync all notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,13 +375,13 @@ gnsync - is an additional application, that is install with Geeknote. gnsync all
 --notebook &lt;notebook where to save&gt;
 :   You can set the notebook which will be syncronized with local directory. But if you won't set this option, *gnsync* will create new notebook with the name of the directory that you want to sync.
 
---all &lt;whether to synchronize all notebooks&gt;
+--all
 :   You can specify to synchronize all notebooks already on the server, into subdirectories of the path. Useful with --two-way to do a backup of all notes.
 
 --logpath &lt;path to logfile&gt;
 :   *gnsync* can log information about syncing and with that option you can set the logfile.
 
---two-way &lt;whether to do a two-way sync&gt;
+--two-way
 :   Normally *gnsync* will only upload files. Adding this flag will also make it download any notes not present as files in the notebook directory (after uploading any files not present as notes)
 
 ### Description

--- a/README.md
+++ b/README.md
@@ -357,8 +357,10 @@ gnsync - is an additional application, that is install with Geeknote. gnsync all
     $ gnsync --path <path to directory which to sync>
             [--mask <unix shell-style wildcards to select the files, like *.* or *.txt or *.log>]
             [--format <in what format to save the note - plain or markdown>]
-            [--logpath <path to logfile>]
             [--notebook <notebook, which will be used>]
+            [--all]
+            [--logpath <path to logfile>]
+            [--two-way]
 ### Options
 
 --path &lt;path to directory which to sync&gt;
@@ -370,11 +372,17 @@ gnsync - is an additional application, that is install with Geeknote. gnsync all
 --format &lt;in what format to save the note - plain or markdown&gt;
 :   Set the engine which to use while files uploading. *gnsync* supports markdown and plain text formats. By default it uses plain text engine.
 
+--notebook &lt;notebook where to save&gt;
+:   You can set the notebook which will be syncronized with local directory. But if you won't set this option, *gnsync* will create new notebook with the name of the directory that you want to sync.
+
+--all &lt;whether to synchronize all notebooks&gt;
+:   You can specify to synchronize all notebooks already on the server, into subdirectories of the path. Useful with --two-way to do a backup of all notes.
+
 --logpath &lt;path to logfile&gt;
 :   *gnsync* can log information about syncing and with that option you can set the logfile.
 
---notebook &lt;notebook where to save&gt;
-:   You can set the notebook which will be syncronized with local directory. But if you won't set this option, *gnsync* will create new notebook with the name of the directory that you want to sync.
+--two-way &lt;whether to do a two-way sync&gt;
+:   Normally *gnsync* will only upload files. Adding this flag will also make it download any notes not present as files in the notebook directory (after uploading any files not present as notes)
 
 ### Description
 The application *gnsync* is very useful in system adminstration, because you can syncronize you local logs, statuses and any other production information with Evernote.

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ gnsync - is an additional application, that is install with Geeknote. gnsync all
             [--all]
             [--logpath <path to logfile>]
             [--two-way]
+            [--download]
 ### Options
 
 --path &lt;path to directory which to sync&gt;
@@ -376,13 +377,16 @@ gnsync - is an additional application, that is install with Geeknote. gnsync all
 :   You can set the notebook which will be syncronized with local directory. But if you won't set this option, *gnsync* will create new notebook with the name of the directory that you want to sync.
 
 --all
-:   You can specify to synchronize all notebooks already on the server, into subdirectories of the path. Useful with --two-way to do a backup of all notes.
+:   You can specify to synchronize all notebooks already on the server, into subdirectories of the path. Useful with --download to do a backup of all notes.
 
 --logpath &lt;path to logfile&gt;
 :   *gnsync* can log information about syncing and with that option you can set the logfile.
 
 --two-way
 :   Normally *gnsync* will only upload files. Adding this flag will also make it download any notes not present as files in the notebook directory (after uploading any files not present as notes)
+
+--download-only
+:   Normally *gnsync* will only upload files. Adding this flag will make it download notes, but not upload any files
 
 ### Description
 The application *gnsync* is very useful in system adminstration, because you can syncronize you local logs, statuses and any other production information with Evernote.

--- a/geeknote/gnsync.py
+++ b/geeknote/gnsync.py
@@ -317,9 +317,9 @@ def main():
         parser.add_argument('--mask', '-m', action='store', help='Mask of files to synchronize. Default is "*.*"')
         parser.add_argument('--format', '-f', action='store', default='plain', choices=['plain', 'markdown'], help='The format of the file contents. Default is "plain". Valid values are "plain" and "markdown"')
         parser.add_argument('--notebook', '-n', action='store', help='Notebook name for synchronize. Default is default notebook unless all is selected')
-        parser.add_argument('--logpath', '-l', action='store', help='Path to log file. Default is GeekNoteSync in home dir')
-        parser.add_argument('--two-way', '-t', action='store_true', help='Two-way sync', default=False)
         parser.add_argument('--all', '-a', action='store_true', help='Synchronize all notebooks', default=False)
+        parser.add_argument('--logpath', '-l', action='store', help='Path to log file. Default is GeekNoteSync in home dir')
+        parser.add_argument('--two-way', '-t', action='store_true', help='Two-way sync (also download from evernote)', default=False)
 
         args = parser.parse_args()
 

--- a/geeknote/gnsync.py
+++ b/geeknote/gnsync.py
@@ -318,7 +318,7 @@ def main():
         parser.add_argument('--format', '-f', action='store', default='plain', choices=['plain', 'markdown'], help='The format of the file contents. Default is "plain". Valid values are "plain" and "markdown"')
         parser.add_argument('--notebook', '-n', action='store', help='Notebook name for synchronize. Default is default notebook unless all is selected')
         parser.add_argument('--logpath', '-l', action='store', help='Path to log file. Default is GeekNoteSync in home dir')
-        parser.add_argument('--two-way', '-t', action='store', help='Two-way sync')
+        parser.add_argument('--two-way', '-t', action='store_true', help='Two-way sync', default=False)
         parser.add_argument('--all', '-a', action='store_true', help='Synchronize all notebooks', default=False)
 
         args = parser.parse_args()
@@ -328,7 +328,7 @@ def main():
         format = args.format if args.format else None
         notebook = args.notebook if args.notebook else None
         logpath = args.logpath if args.logpath else None
-        twoway = True if args.two_way else False
+        twoway = args.two_way
 
         reset_logpath(logpath)
 

--- a/geeknote/gnsync.py
+++ b/geeknote/gnsync.py
@@ -73,6 +73,9 @@ def reset_logpath(logpath):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
+def all_notebooks():
+    geeknote = GeekNote()
+    return [notebook.name for notebook in geeknote.findNotebooks()]
 
 class GNSync:
 
@@ -313,9 +316,10 @@ def main():
         parser.add_argument('--path', '-p', action='store', help='Path to synchronize directory')
         parser.add_argument('--mask', '-m', action='store', help='Mask of files to synchronize. Default is "*.*"')
         parser.add_argument('--format', '-f', action='store', default='plain', choices=['plain', 'markdown'], help='The format of the file contents. Default is "plain". Valid values are "plain" and "markdown"')
-        parser.add_argument('--notebook', '-n', action='store', help='Notebook name for synchronize. Default is default notebook')
+        parser.add_argument('--notebook', '-n', action='store', help='Notebook name for synchronize. Default is default notebook unless all is selected')
         parser.add_argument('--logpath', '-l', action='store', help='Path to log file. Default is GeekNoteSync in home dir')
         parser.add_argument('--two-way', '-t', action='store', help='Two-way sync')
+        parser.add_argument('--all', '-a', action='store_true', help='Synchronize all notebooks', default=False)
 
         args = parser.parse_args()
 
@@ -328,8 +332,16 @@ def main():
 
         reset_logpath(logpath)
 
-        GNS = GNSync(notebook, path, mask, format, twoway)
-        GNS.sync()
+        if args.all:
+            for notebook in all_notebooks():
+                notebook_path = os.path.join(path, notebook)
+                if not os.path.exists(notebook_path):
+                    os.mkdir(notebook_path)
+                GNS = GNSync(notebook, notebook_path, mask, format, twoway)
+                GNS.sync()
+        else:
+            GNS = GNSync(notebook, path, mask, format, twoway)
+            GNS.sync()
 
     except (KeyboardInterrupt, SystemExit, tools.ExitException):
         pass


### PR DESCRIPTION
Added a `--all` flag that allows syncing all notebooks, which is a useful way to backup together with `--two-way` or (newly introduced) `--download-only`. Also clarified and updated docs on `gnsync`
