### PR TITLE
Add support to Yinxiang Biji.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ If you want to change Evernote user you should launch *logout* command:
 
 And after you can repeat authorization step.
 
+### Yinxiang Biji user
+
+If you want to use Evernote's separate service in China Yinxiang Biji (印象笔记),
+you need to set the environment variable `GEEKNOTE_BASE` to `yinxiang`.
+
+    $ GEEKNOTE_BASE=yinxiang geeknote login
+
+Yinxiang Biji (印象笔记) is faster in China and it supports Chinese payment method.
+Be aware that Yinxiang Biji will not have support for sharing social features
+like twitter and facebook. And since data are stored on servers in China,
+Chinese authorities have the right to access their data according to current
+regulations.
+
+For more information, see:
+
+https://blog.evernote.com/blog/2012/05/09/evernote-launches-separate-chinese-service/
+
 ###Look your settings
 
     $ geeknote settings

--- a/geeknote/config.py
+++ b/geeknote/config.py
@@ -4,8 +4,11 @@ import os
 import sys
 
 # !!! DO NOT EDIT !!! >>>
-USER_BASE_URL = "www.evernote.com"
-USER_STORE_URI = "https://www.evernote.com/edam/user"
+if os.getenv("GEEKNOTE_BASE") == "yinxiang":
+    USER_BASE_URL = "app.yinxiang.com"
+else:
+    USER_BASE_URL = "www.evernote.com"
+USER_STORE_URI = "https://{}/edam/user".format(USER_BASE_URL)
 CONSUMER_KEY = "skaizer-5314"
 CONSUMER_SECRET = "6f4f9183b3120801"
 


### PR DESCRIPTION
Add support to Evernote's separate service in China Yinxiang Biji
(印象笔记).
Set environment variable `GEEKNOTE_BASE` to `yinxiang` to use it.

Close #99 (https://github.com/VitaliyRodnenko/geeknote/issues/100).