### PR TITLE
fix parsing hpts and hptsh for login form

### DIFF
--- a/geeknote/oauth.py
+++ b/geeknote/oauth.py
@@ -190,8 +190,8 @@ class GeekNoteAuth(object):
                                  {'oauth_token': self.tmpOAuthToken})
 
         # parse hpts and hptsh from page content
-        hpts = re.search('.*"hpts":"(.*?)"', response.data)
-        hptsh = re.search('.*"hptsh":"(.*?)"', response.data)
+        hpts = re.search('.*\("hpts"\)\.value.*?"(.*?)"', response.data)
+        hptsh = re.search('.*\("hptsh"\)\.value.*?"(.*?)"', response.data)
 
         if response.status != 200:
             logging.error("Unexpected response status "


### PR DESCRIPTION
This should fix #288.

Please refer to this commit in [evernote-sdk-lua](https://github.com/koreader/evernote-sdk-lua/commit/cfe65376a5ee04ca8f1f10993f5ff9cceaad2857) used in [KoReader](https://github.com/koreader/koreader).