### PR TITLE
gnsync create/update files in "plain" or "markdown" format

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -75,7 +75,7 @@ class Editor(object):
 
 
     @staticmethod
-    def ENMLtoText(contentENML):
+    def ENMLtoText(contentENML, markdown=True):
         soup = BeautifulSoup(contentENML.decode('utf-8'))
 
         for section in soup.select('li > p'):
@@ -97,8 +97,10 @@ class Editor(object):
 
         for section in soup.findAll('en-todo'):
             section.replace_with('[ ]')
-
-        content = html2text.html2text(str(soup).decode('utf-8'), '', 0)
+        if markdown:
+            content = html2text.html2text(str(soup).decode('utf-8'), '', 0)
+        else:
+            content = soup.get_text()
         content = re.sub(r' *\n', os.linesep, content)
 
         return content.encode('utf-8')

--- a/geeknote/gnsync.py
+++ b/geeknote/gnsync.py
@@ -191,7 +191,7 @@ class GNSync:
         Updates file from note
         """
         GeekNote().loadNoteContent(note)
-        content = Editor.ENMLtoText(note.content)
+        content = Editor.ENMLtoText(note.content, self.format == "markdown")
         open(file_note['path'], "w").write(content)
 
     @log
@@ -225,7 +225,7 @@ class GNSync:
         Creates file from note
         """
         GeekNote().loadNoteContent(note)
-        content = Editor.ENMLtoText(note.content)
+        content = Editor.ENMLtoText(note.content, self.format == "markdown")
         path = os.path.join(self.path, note.title + self.extension)
         open(path, "w").write(content)
         return True
@@ -240,7 +240,7 @@ class GNSync:
         # strip unprintable characters
         content = remove_control_characters(content.decode('utf-8')).encode('utf-8')
         content = Editor.textToENML(content=content, raise_ex=True, format=self.format)
-        
+
         if content is None:
             logger.warning("File {0}. Content must be " \
                            "an UTF-8 encode.".format(path))


### PR DESCRIPTION
Hi,

Some of my notes in Evernote are wrote in markdown format. When I used gnsync -t TWO_WAY, all the markdown is escaped. The format parameter has no impact on this.

This pull request take into account the format parameter. If format is plain, the result file is not transform using html2text.

As the default format is "plain", if the format was not force by the parameter in the command line, the program's behavior is change.