### PR TITLE
Add ability to specify a notebook stack when creating a new notebook

### DIFF
--- a/geeknote/argparser.py
+++ b/geeknote/argparser.py
@@ -146,6 +146,7 @@ COMMANDS_DICT = {
         "arguments": {
             "--title": {"altName": "-t",
                         "help": "Set the title of new notebook."},
+            "--stack": {"help": "Specify notebook stack container."},
         }
     },
     "notebook-edit": {

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -290,9 +290,11 @@ class GeekNote(object):
         return self.getNoteStore().listNotebooks(self.authToken)
 
     @EdamException
-    def createNotebook(self, name):
+    def createNotebook(self, name, stack):
         notebook = Types.Notebook()
         notebook.name = name
+        if stack:
+            notebook.stack = stack
 
         logging.debug("New notebook : %s", notebook)
 
@@ -515,10 +517,10 @@ class Notebooks(GeekNoteConnector):
         result = self.getEvernote().findNotebooks()
         out.printList(result)
 
-    def create(self, title):
+    def create(self, title, stack=None):
         self.connectToEvertone()
         out.preloader.setMessage("Creating notebook...")
-        result = self.getEvernote().createNotebook(name=title)
+        result = self.getEvernote().createNotebook(name=title, stack=stack)
 
         if result:
             out.successMessage("Notebook has been successfully created.")


### PR DESCRIPTION
Added a new optional argument to "notebook-create" to allow the user to specify a notebook stack.  The notebook stack is create (automatically via the Evernote API) if it doesn't already exist.

Usage:

````
geeknote notebook-create --title "Test Notebook" --stack "Test Stack"
```