### PR TITLE
Date format bug and display format change

### DIFF
--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -284,7 +284,7 @@ def printDate(timestamp):
 
     # ---
     
-    return datetime.date.strftime(datetime.date.fromtimestamp(timestamp / 1000), "%d.%m.%Y")
+    return datetime.date.strftime(datetime.date.fromtimestamp(timestamp), "%d.%m.%Y")
 
 def printLine(line, endLine="\n", out=sys.stdout):
     message = line + endLine

--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -284,7 +284,7 @@ def printDate(timestamp):
 
     # ---
     
-    return datetime.date.strftime(datetime.date.fromtimestamp(timestamp), "%d.%m.%Y")
+    return datetime.date.strftime(datetime.date.fromtimestamp(timestamp), "%Y-%m-%d")
 
 def printLine(line, endLine="\n", out=sys.stdout):
     message = line + endLine


### PR DESCRIPTION
81d6611 use ISO 8601 date format for better readability
d52e1f6 no need to divide by 1000, otherwise out date will be wrong
