### PR TITLE
no need to divide by 1000, otherwise out date will be wrong

### DIFF
--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -284,7 +284,7 @@ def printDate(timestamp):
 
     # ---
     
-    return datetime.date.strftime(datetime.date.fromtimestamp(timestamp / 1000), "%d.%m.%Y")
+    return datetime.date.strftime(datetime.date.fromtimestamp(timestamp), "%d.%m.%Y")
 
 def printLine(line, endLine="\n", out=sys.stdout):
     message = line + endLine


### PR DESCRIPTION
datestamp: 1342295928000
div by 1K: 16.01.1970
no divide: 15.07.2012 <-- correct

this fixed #285 
without reproducing of #259