### PR TITLE
supress BeautifulSoup warning

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -76,7 +76,7 @@ class Editor(object):
 
     @staticmethod
     def ENMLtoText(contentENML):
-        soup = BeautifulSoup(contentENML.decode('utf-8'))
+        soup = BeautifulSoup(contentENML.decode('utf-8'), 'lxml')
 
         for section in soup.select('li > p'):
             section.replace_with( section.contents[0] )


### PR DESCRIPTION
the warning message as below
```
/usr/lib/python2.7/site-packages/beautifulsoup4-4.4.0-py2.7.egg/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "lxml")
```