### PR TITLE
Adding option to flush notebook list to use in backup scripts.

### DIFF
--- a/geeknote/argparser.py
+++ b/geeknote/argparser.py
@@ -140,6 +140,11 @@ COMMANDS_DICT = {
     # Notebooks
     "notebook-list": {
         "help": "Show the list of existing notebooks in your Evernote.",
+        "flags": {
+            "--flush": {"help": "Lists all notebooks at once without asking for user input.",
+            "value": True,
+            "default": False},
+        }
     },
     "notebook-create": {
         "help": "Create new notebook.",

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -511,9 +511,10 @@ class Tags(GeekNoteConnector):
 class Notebooks(GeekNoteConnector):
     """ Work with auth Notebooks """
 
-    def list(self):
+    def list(self, flush):
         result = self.getEvernote().findNotebooks()
-        out.printList(result)
+        out.printList(result,flush=flush)
+
 
     def create(self, title):
         self.connectToEvertone()
@@ -907,6 +908,9 @@ def main(args=None):
         # Notebooks
         if COMMAND == 'notebook-list':
             Notebooks().list(**ARGS)
+
+        if COMMAND == 'notebook-list-all':
+            Notebooks().listAll(**ARGS)
 
         if COMMAND == 'notebook-create':
             Notebooks().create(**ARGS)

--- a/geeknote/out.py
+++ b/geeknote/out.py
@@ -226,13 +226,16 @@ def separator(symbol="", title=""):
 
 @preloaderStop
 def printList(listItems, title="", showSelector=False,
-              showByStep=20, showUrl=False):
+              showByStep=20, showUrl=False, flush=False):
 
     if title:
         separator("=", title)
 
     total = len(listItems)
-    printLine("Total found: %d" % total)
+    if not flush:
+        printLine("Total found: %d" % total)
+    else:
+        showByStep=float("inf") # don't ask user for more
     for key, item in enumerate(listItems):
         key += 1
 


### PR DESCRIPTION
Since a lot of people (including myself) wants to use Geeknote for automatized backup scripts, I'd written a ```--flush``` flag for ```geeknote notebook-list```. Still didn't change the overall syntax of the output notebook list, even I think it could be usefull to only have the names (no numbering). 

Hope you like it.