### PR TITLE
Saveimages

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -90,7 +90,7 @@ class Editor(object):
 
 
     @staticmethod
-    def ENMLtoText(contentENML, imageOptions={'saveImages': False}, imageFilename=""):
+    def ENMLtoText(contentENML, imageOptions={'saveImages': False}):
         soup = BeautifulSoup(contentENML.decode('utf-8'))
 
         for section in soup.select('li > p'):

--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -47,6 +47,21 @@ class Editor(object):
     def HTMLUnescape(text):
         return unescape(text, Editor.getHtmlUnescapeTable())
 
+ 
+    @staticmethod
+    def getImages(contentENML):
+        '''
+        creates a list of image resources to save. each has a hash and extension attribute
+        '''
+        soup = BeautifulSoup(contentENML.decode('utf-8'))
+        imageList = []
+        for section in soup.findAll('en-media'):
+            if 'type' in section.attrs and 'hash' in section.attrs:
+                imageType, imageExtension = section['type'].split('/')
+                if imageType == "image":
+                    imageList.append({'hash': section['hash'], 'extension': imageExtension})
+        return imageList
+
     @staticmethod
     def checklistInENMLtoSoup(soup):
         '''
@@ -75,7 +90,7 @@ class Editor(object):
 
 
     @staticmethod
-    def ENMLtoText(contentENML):
+    def ENMLtoText(contentENML, imageOptions={'saveImages': False}, imageFilename=""):
         soup = BeautifulSoup(contentENML.decode('utf-8'))
 
         for section in soup.select('li > p'):
@@ -97,6 +112,16 @@ class Editor(object):
 
         for section in soup.findAll('en-todo'):
             section.replace_with('[ ]')
+
+        # change <en-media> tags to <img> tags
+        if 'saveImages' in imageOptions and imageOptions['saveImages']:
+            for section in soup.findAll('en-media'):
+                if 'type' in section.attrs and 'hash' in section.attrs:
+                    imageType, imageExtension = section['type'].split('/')
+                    if imageType == "image":
+                        newTag = soup.new_tag("img")
+                        newTag['src'] = "{}-{}.{}".format(imageOptions['baseFilename'], section['hash'], imageExtension)
+                        section.replace_with(newTag)
 
         content = html2text.html2text(str(soup).decode('utf-8'), '', 0)
         content = re.sub(r' *\n', os.linesep, content)

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -69,7 +69,6 @@ class GeekNote(object):
             except Exception, e:
                 logging.error("Error: %s : %s", func.__name__, str(e))
 
-                print(str(e))
                 if not hasattr(e, 'errorCode'):
                     out.failureMessage("Sorry, operation has failed!!!.")
                     tools.exitErr()

--- a/geeknote/geeknote.py
+++ b/geeknote/geeknote.py
@@ -69,6 +69,7 @@ class GeekNote(object):
             except Exception, e:
                 logging.error("Error: %s : %s", func.__name__, str(e))
 
+                print(str(e))
                 if not hasattr(e, 'errorCode'):
                     out.failureMessage("Sorry, operation has failed!!!.")
                     tools.exitErr()
@@ -350,6 +351,13 @@ class GeekNote(object):
         self.getNoteStore().expungeTag(self.authToken, guid)
         return True
 
+    @EdamException
+    def saveMedia(self, guid, mediaHash, filename):
+        logging.debug("saveMedia: guid:{}, mediaHash:{}, filename:{}".format(guid, mediaHash, filename))
+
+        resource = self.getNoteStore().getResourceByHash(self.authToken, guid, mediaHash, True, False, False)
+        open(filename, "w").write(resource.data.body)
+        return True
 
 class GeekNoteConnector(object):
     evernote = None


### PR DESCRIPTION
Add an option to gnsync to download all note images and add an image link in the markdown.

Add command line flags (default: off) 
--save-images: saves the images and adds a markdown link
--images-in-subdir: saves the images in a subdirectory named {note.title}_images. Default is to save in the same directory
