### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ As we mentioned before, *show* can use the results of previous search, so if you
 You can remove notes with Geeknotes from Evernote.
 
 ### Synopsis
-    $ geeknote remove --notebook <note name>
+    $ geeknote remove --note <note name>
                      [--force]
 ### Options
 


### PR DESCRIPTION
    geeknote remove --notebook <note name>

does not exist. It must be:

    geeknote remove --note <note name>