### PR TITLE
Add support for Chinese special edition.

### DIFF
--- a/geeknote/config.py
+++ b/geeknote/config.py
@@ -5,7 +5,9 @@ import sys
 
 # !!! DO NOT EDIT !!! >>>
 USER_BASE_URL = "www.evernote.com"
-USER_STORE_URI = "https://www.evernote.com/edam/user"
+if (os.getenv('EVERNOTE_ZH') != None):
+    USER_BASE_URL = "app.yinxiang.com"
+USER_STORE_URI = "https://" + USER_BASE_URL + "/edam/user"
 CONSUMER_KEY = "skaizer-5314"
 CONSUMER_SECRET = "6f4f9183b3120801"
 


### PR DESCRIPTION
There is a problem in geeknote. Other than Evernote, namely Evernote Intenational, there is a special official version in China called yinxiang with server deployed in China providing almost the same API. We should change the address of evernote from www.evernote.com into app.yinxiang.com to use geeknote in China. Just set a EVERNOTE_ZH:
export EVERNOTE_ZH=
Then it will use Chinese version.