### PR TITLE
adds second parameter to BeautifulSoup call to suppress warning

### DIFF
--- a/geeknote/editor.py
+++ b/geeknote/editor.py
@@ -76,7 +76,7 @@ class Editor(object):
 
     @staticmethod
     def ENMLtoText(contentENML):
-        soup = BeautifulSoup(contentENML.decode('utf-8'))
+        soup = BeautifulSoup(contentENML.decode('utf-8'), 'html.parser')
 
         for section in soup.select('li > p'):
             section.replace_with( section.contents[0] )


### PR DESCRIPTION
Adds the 'html.parser' to the other BeautifulSoup call so that there is no longer a warning at runtime.